### PR TITLE
Migration/kas 1422 models agendaitem subcase

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -52,7 +52,7 @@ const getAgendaPriorities = async (agendaId) => {
             ?subcase ext:wordtGetoondAlsMededeling ?showAsRemark .
             FILTER(?showAsRemark ="false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>)    
             OPTIONAL { 
-                ?subcase besluitvorming:heeftBevoegde ?mandatee . 
+                ?subcase ext:heeftBevoegde ?mandatee . 
                 ?mandatee mu:uuid ?mandateeId .
                 ?mandatee mandaat:rangorde ?priority .
                 ?mandatee mandaat:start ?start .
@@ -96,7 +96,7 @@ const getAgendaPrioritiesWithoutFilter = async (agendaId) => {
             FILTER(?showAsRemark ="false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>)
 
             OPTIONAL { 
-                ?subcase besluitvorming:heeftBevoegde ?mandatee . 
+                ?subcase ext:heeftBevoegde ?mandatee . 
                 ?mandatee mu:uuid ?mandateeId .
                 ?mandatee mandaat:rangorde ?priority .
                 ?mandatee mandaat:start ?start .
@@ -214,7 +214,7 @@ const getAllAgendaItemsFromAgendaWithDocuments = async (agendaId) => {
          }
          ?agendaitem   ext:wordtGetoondAlsMededeling ?showAsRemark .
          OPTIONAL { 
-            ?agendaitem ext:bevatAgendapuntDocumentversie ?documentVersions .
+            ?agendaitem besluitvorming:bevatAgendapuntDocumentversie ?documentVersions .
             ?document   dossier:collectie.bestaatUit ?documentVersions .
          }
          FILTER(?showAsRemark ="false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>)

--- a/repository/index.js
+++ b/repository/index.js
@@ -214,7 +214,7 @@ const getAllAgendaItemsFromAgendaWithDocuments = async (agendaId) => {
          }
          ?agendaitem   ext:wordtGetoondAlsMededeling ?showAsRemark .
          OPTIONAL { 
-            ?agendaitem besluitvorming:bevatAgendapuntDocumentversie ?documentVersions .
+            ?agendaitem besluitvorming:geagendeerdStuk ?documentVersions .
             ?document   dossier:collectie.bestaatUit ?documentVersions .
          }
          FILTER(?showAsRemark ="false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>)


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- besluitvorming:heeftBevoegde => ext:heeftBevoegde
- ext:bevatAgendapuntDocumentversie => besluitvorming:geagendeerdStuk