### PR TITLE
Migration/kas 1388 replacement of document version instead of addition

### DIFF
--- a/repository/compare-agenda.js
+++ b/repository/compare-agenda.js
@@ -8,17 +8,17 @@ const getAllAgendaItemsFromAgendaWithDocuments = async (agendaId) => {
     PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-   
-    SELECT ?subcaseId ?id ?documentVersions ?document WHERE { 
+
+    SELECT ?subcaseId ?id ?documentVersions ?document WHERE {
       ?agenda a besluitvorming:Agenda ;
                 mu:uuid ${sparqlEscapeString(agendaId)} .
       ?agenda   dct:hasPart ?agendaitem .
       ?agendaitem mu:uuid ?id .
-      OPTIONAL { 
+      OPTIONAL {
         ?subcase  ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem ;
                     mu:uuid ?subcaseId .
       }
-      OPTIONAL { 
+      OPTIONAL {
         ?agendaitem besluitvorming:geagendeerdStuk ?documentVersions .
         ?document   dossier:collectie.bestaatUit ?documentVersions .
       }
@@ -47,7 +47,7 @@ const reduceDocumentsAndDocumentVersions = (agendaitems) => {
         agendaItems[foundIndex].allDocumentVersions.push(agendaitem.documentVersions);
         const foundDocument = agendaItems[foundIndex].documents.find(document => document.id === agendaitem.document);
         if (foundDocument) {
-          foundDocument.documentVersions.push(agendaitem.documentVersions)
+          foundDocument.documentVersions.push(agendaitem.documentVersions);
         } else {
           agendaItems[foundIndex].documents.push({
             id: agendaitem.document,
@@ -59,6 +59,7 @@ const reduceDocumentsAndDocumentVersions = (agendaitems) => {
     return agendaItems;
   }, []);
 };
+
 
 const isDocumentAdded = (previousItem, document) => {
   return !previousItem.documents.find(previousDocument => previousDocument.id === document.id);

--- a/repository/compare-agenda.js
+++ b/repository/compare-agenda.js
@@ -67,7 +67,17 @@ const isDocumentAdded = (previousItem, document) => {
 
 const isVersionAdded = (previousItem, document) => {
   const previousDocument = previousItem.documents.find(previousDocument => previousDocument.id === document.id);
-  return previousDocument && previousDocument.documentVersions.length < document.documentVersions.length;
+
+  if (previousDocument) {
+    for (let i = 0; i < document.documentVersions.length; i++) {
+      const documentVersion = document.documentVersions[i];
+      if (!previousDocument.documentVersions.includes(documentVersion)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 };
 
 export {


### PR DESCRIPTION
This PR continues on the refactored code of #5 and updates the logic to determine whether a document version is a new version on an agendaitem.
   
Since new document versions are no longer simply appended to the current list of document versions on an agenaditem, but replace the previous versions, the check on length of document versions isn't valid anymore. Instead we need to compare the document versions on both agendaitems one-by-one.